### PR TITLE
Put RowGenerators in the Results object

### DIFF
--- a/src/main/java/com/teradata/tpcds/row/generator/CallCenterRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CallCenterRowGenerator.java
@@ -76,7 +76,7 @@ public class CallCenterRowGenerator
     private Optional<CallCenterRow> previousRow = Optional.empty();
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         CallCenterRow.Builder builder = new CallCenterRow.Builder();
         builder.setNullBitMap(createNullBitMap(CC_NULLS));

--- a/src/main/java/com/teradata/tpcds/row/generator/CatalogPageRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CatalogPageRowGenerator.java
@@ -34,7 +34,7 @@ public class CatalogPageRowGenerator
     private static final int WIDTH_CP_DESCRIPTION = 100;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long cpCatalogPageSk = rowNumber;
         String cpDepartment = "DEPARTMENT";

--- a/src/main/java/com/teradata/tpcds/row/generator/CatalogReturnsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CatalogReturnsRowGenerator.java
@@ -55,12 +55,12 @@ public class CatalogReturnsRowGenerator
     public static final int RETURN_PERCENT = 10;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         // The catalog returns table is a child of the catalog_sales table because you can only return things that have
         // already been purchased.  This method should only get called if we are generating the catalog_returns table
         // in isolation. Otherwise catalog_returns is generated during the generation of the catalog_sales table
-        RowGeneratorResult salesAndReturnsResult = CATALOG_SALES.getRowGenerator().generateRowAndChildRows(rowNumber, session);
+        RowGeneratorResult salesAndReturnsResult = parentRowGenerator.generateRowAndChildRows(rowNumber, session, null , this);
         if (salesAndReturnsResult.getRowAndChildRows().size() == 2) {
             return new RowGeneratorResult(ImmutableList.of(salesAndReturnsResult.getRowAndChildRows().get(1)), salesAndReturnsResult.shouldEndRow());
         }

--- a/src/main/java/com/teradata/tpcds/row/generator/CatalogSalesRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CatalogSalesRowGenerator.java
@@ -93,7 +93,7 @@ public class CatalogSalesRowGenerator
     private int ticketItemBase;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         int itemCount = (int) session.getScaling().getIdCount(ITEM);
         if (itemPermutation == null) {
@@ -161,7 +161,7 @@ public class CatalogSalesRowGenerator
         // if the sale gets returned, generate a return row
         int randomInt = generateUniformRandomInt(0, 99, CR_IS_RETURNED.getRandomNumberStream());
         if (randomInt < CatalogReturnsRowGenerator.RETURN_PERCENT && (!session.generateOnlyOneTable() || session.getOnlyTableToGenerate() != CATALOG_SALES)) {
-            TableRow catalogReturnsRow = ((CatalogReturnsRowGenerator) CATALOG_RETURNS.getRowGenerator()).generateRow(session, catalogSalesRow);
+            TableRow catalogReturnsRow = ((CatalogReturnsRowGenerator) childRowGenerator).generateRow(session, catalogSalesRow);
             generatedRows.add(catalogReturnsRow);
         }
 

--- a/src/main/java/com/teradata/tpcds/row/generator/CustomerAddressRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CustomerAddressRowGenerator.java
@@ -31,7 +31,7 @@ public class CustomerAddressRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(CA_NULLS);
         long caAddrSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/CustomerDemographicsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CustomerDemographicsRowGenerator.java
@@ -38,7 +38,7 @@ public class CustomerDemographicsRowGenerator
     private static final int MAX_COLLEGE = 7;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(CD_NULLS);
         long cDemoSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/CustomerRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CustomerRowGenerator.java
@@ -59,7 +59,7 @@ public class CustomerRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long cCustomerSk = rowNumber;
         String cCustomerId = makeBusinessKey(rowNumber);

--- a/src/main/java/com/teradata/tpcds/row/generator/DateDimRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/DateDimRowGenerator.java
@@ -41,7 +41,7 @@ public class DateDimRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(D_NULLS);
 

--- a/src/main/java/com/teradata/tpcds/row/generator/DbgenVersionRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/DbgenVersionRowGenerator.java
@@ -26,7 +26,7 @@ public class DbgenVersionRowGenerator
     private static final String DBGEN_VERSION = "2.0.0";
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         DateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");

--- a/src/main/java/com/teradata/tpcds/row/generator/HouseholdDemographicsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/HouseholdDemographicsRowGenerator.java
@@ -30,7 +30,7 @@ public class HouseholdDemographicsRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(HD_NULLS);
         long hdDemoSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/IncomeBandRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/IncomeBandRowGenerator.java
@@ -26,7 +26,7 @@ public class IncomeBandRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(IB_NULLS);
         int ibIncomeBandId = (int) rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/InventoryRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/InventoryRowGenerator.java
@@ -31,7 +31,7 @@ public class InventoryRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(INV_NULLS);
         int index = (int) rowNumber - 1;

--- a/src/main/java/com/teradata/tpcds/row/generator/ItemRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/ItemRowGenerator.java
@@ -86,7 +86,7 @@ public class ItemRowGenerator
     private Optional<ItemRow> previousRow = Optional.empty();
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(I_NULLS);
         long iItemSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/PromotionRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/PromotionRowGenerator.java
@@ -46,7 +46,7 @@ public class PromotionRowGenerator
     private static final int PROMO_DETAIL_LENGTH_MAX = 60;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(P_NULLS);
         long pPromoSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/ReasonRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/ReasonRowGenerator.java
@@ -26,7 +26,7 @@ public class ReasonRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(R_NULLS);
         long rReasonSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/RowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/RowGenerator.java
@@ -18,7 +18,7 @@ import com.teradata.tpcds.Session;
 
 public interface RowGenerator
 {
-    RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session);
+    RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator);
 
     void reset();
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/ShipModeRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/ShipModeRowGenerator.java
@@ -32,7 +32,7 @@ public class ShipModeRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(SM_NULLS);
         long smShipModeSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/StoreReturnsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/StoreReturnsRowGenerator.java
@@ -53,12 +53,12 @@ public class StoreReturnsRowGenerator
     private static final int SR_SAME_CUSTOMER = 80;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         // The store_returns table is a child of the store_sales table because you can only return things that have
         // already been purchased.  This method should only get called if we are generating the store_returns table
         // in isolation. Otherwise store_returns is generated during the generation of the store_sales table
-        RowGeneratorResult salesAndReturnsResult = STORE_SALES.getRowGenerator().generateRowAndChildRows(rowNumber, session);
+        RowGeneratorResult salesAndReturnsResult = parentRowGenerator.generateRowAndChildRows(rowNumber, session, null, this);
         if (salesAndReturnsResult.getRowAndChildRows().size() == 2) {
             return new RowGeneratorResult(ImmutableList.of(salesAndReturnsResult.getRowAndChildRows().get(1)), salesAndReturnsResult.shouldEndRow());
         }

--- a/src/main/java/com/teradata/tpcds/row/generator/StoreRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/StoreRowGenerator.java
@@ -66,7 +66,7 @@ public class StoreRowGenerator
     private Optional<StoreRow> previousRow = Optional.empty();
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(W_STORE_NULLS);
         long storeSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/StoreSalesRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/StoreSalesRowGenerator.java
@@ -72,7 +72,7 @@ public class StoreSalesRowGenerator
     private int itemIndex;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         int itemCount = (int) session.getScaling().getIdCount(ITEM);
         if (itemPermutation == null) {
@@ -119,7 +119,7 @@ public class StoreSalesRowGenerator
         // if the sale gets returned, generate a return row
         int randomInt = generateUniformRandomInt(0, 99, SR_IS_RETURNED.getRandomNumberStream());
         if (randomInt < SR_RETURN_PCT && (!session.generateOnlyOneTable() || session.getOnlyTableToGenerate() != STORE_SALES)) {
-            generatedRows.add(((StoreReturnsRowGenerator) STORE_RETURNS.getRowGenerator()).generateRow(session, storeSalesRow));
+            generatedRows.add(((StoreReturnsRowGenerator) childRowGenerator).generateRow(session, storeSalesRow));
         }
 
         remainingLineItems--;

--- a/src/main/java/com/teradata/tpcds/row/generator/TimeDimRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/TimeDimRowGenerator.java
@@ -27,7 +27,7 @@ public class TimeDimRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(T_NULLS);
         long tTimeSk = rowNumber - 1;

--- a/src/main/java/com/teradata/tpcds/row/generator/WarehouseRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WarehouseRowGenerator.java
@@ -32,7 +32,7 @@ public class WarehouseRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(W_NULLS);
         long wWarehouseSk = rowNumber;

--- a/src/main/java/com/teradata/tpcds/row/generator/WebPageRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WebPageRowGenerator.java
@@ -52,7 +52,7 @@ public class WebPageRowGenerator
     private Optional<WebPageRow> previousRow = Optional.empty();
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         Scaling scaling = session.getScaling();
 

--- a/src/main/java/com/teradata/tpcds/row/generator/WebReturnsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WebReturnsRowGenerator.java
@@ -49,9 +49,9 @@ public class WebReturnsRowGenerator
         implements RowGenerator
 {
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        RowGeneratorResult salesAndReturnsResult = WEB_SALES.getRowGenerator().generateRowAndChildRows(rowNumber, session);
+        RowGeneratorResult salesAndReturnsResult = parentRowGenerator.generateRowAndChildRows(rowNumber, session, null, this);
         if (salesAndReturnsResult.getRowAndChildRows().size() == 2) {
             return new RowGeneratorResult(ImmutableList.of(salesAndReturnsResult.getRowAndChildRows().get(1)), salesAndReturnsResult.shouldEndRow());
         }

--- a/src/main/java/com/teradata/tpcds/row/generator/WebSalesRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WebSalesRowGenerator.java
@@ -86,7 +86,7 @@ public class WebSalesRowGenerator
     private int itemIndex;
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         Scaling scaling = session.getScaling();
         int itemCount = (int) scaling.getIdCount(ITEM);
@@ -150,7 +150,7 @@ public class WebSalesRowGenerator
         // if the item gets returned, generate a returns row
         int randomInt = generateUniformRandomInt(0, 99, WR_IS_RETURNED.getRandomNumberStream());
         if (randomInt < RETURN_PERCENTAGE && (!session.generateOnlyOneTable() || !(session.getOnlyTableToGenerate() == WEB_SALES))) {
-            TableRow returnsRow = ((WebReturnsRowGenerator) (WEB_RETURNS.getRowGenerator())).generateRow(session, salesRow);
+            TableRow returnsRow = ((WebReturnsRowGenerator) childRowGenerator).generateRow(session, salesRow);
             generatedRows.add(returnsRow);
         }
 

--- a/src/main/java/com/teradata/tpcds/row/generator/WebSiteRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WebSiteRowGenerator.java
@@ -64,7 +64,7 @@ public class WebSiteRowGenerator
     private Optional<WebSiteRow> previousRow = Optional.empty();
 
     @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session)
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long nullBitMap = createNullBitMap(WEB_NULLS);
         long webSiteSk = rowNumber;


### PR DESCRIPTION
We need unique objects per result set so that if multiple tables are
being generated at once, they don't interfere with each other's state.