### PR TITLE
Move RandomNumberStreams to RowGenerators

### DIFF
--- a/src/main/java/com/teradata/tpcds/Nulls.java
+++ b/src/main/java/com/teradata/tpcds/Nulls.java
@@ -14,7 +14,6 @@
 
 package com.teradata.tpcds;
 
-import com.teradata.tpcds.generator.GeneratorColumn;
 import com.teradata.tpcds.random.RandomNumberStream;
 
 import static com.teradata.tpcds.random.RandomValueGenerator.generateUniformRandomInt;
@@ -24,11 +23,8 @@ public class Nulls
 {
     private Nulls() {}
 
-    public static long createNullBitMap(GeneratorColumn column)
+    public static long createNullBitMap(Table table, RandomNumberStream randomNumberStream)
     {
-        Table table = column.getTable();
-        RandomNumberStream randomNumberStream = column.getRandomNumberStream();
-
         int threshold = generateUniformRandomInt(0, 9999, randomNumberStream);
         long bitMap = generateUniformRandomKey(1, Integer.MAX_VALUE, randomNumberStream);
 

--- a/src/main/java/com/teradata/tpcds/generator/CallCenterGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/CallCenterGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.CALL_CENTER;
 
@@ -58,25 +56,19 @@ public enum CallCenterGeneratorColumn
     CC_SCD(33, 1),
     CC_NULLS(34, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     CallCenterGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return CALL_CENTER;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -89,5 +81,11 @@ public enum CallCenterGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/CatalogPageGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/CatalogPageGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.CATALOG_PAGE;
 
@@ -35,25 +33,19 @@ public enum CatalogPageGeneratorColumn
     CP_TYPE(44, 1),
     CP_NULLS(45, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     CatalogPageGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return CATALOG_PAGE;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -66,5 +58,11 @@ public enum CatalogPageGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/CatalogReturnsGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/CatalogReturnsGeneratorColumn.java
@@ -55,23 +55,19 @@ public enum CatalogReturnsGeneratorColumn
 
     private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     CatalogReturnsGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
         this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return CATALOG_RETURNS;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -84,5 +80,11 @@ public enum CatalogReturnsGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/CatalogSalesGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/CatalogSalesGeneratorColumn.java
@@ -18,6 +18,8 @@ import com.teradata.tpcds.Table;
 import com.teradata.tpcds.random.RandomNumberStream;
 import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
+import static com.teradata.tpcds.Table.CATALOG_SALES;
+
 public enum CatalogSalesGeneratorColumn
         implements GeneratorColumn
 {
@@ -63,23 +65,19 @@ public enum CatalogSalesGeneratorColumn
 
     private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     CatalogSalesGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
         this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
-        return Table.CATALOG_SALES;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
+        return CATALOG_SALES;
     }
 
     @Override
@@ -92,5 +90,11 @@ public enum CatalogSalesGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/CustomerAddressGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/CustomerAddressGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.CUSTOMER_ADDRESS;
 
@@ -40,25 +38,19 @@ public enum CustomerAddressGeneratorColumn
     CA_ADDRESS(147, 7),
     CA_ADDRESS_STREET_NAME2(148, 1);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     CustomerAddressGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return CUSTOMER_ADDRESS;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -71,5 +63,11 @@ public enum CustomerAddressGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/CustomerDemographicsGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/CustomerDemographicsGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.CUSTOMER_DEMOGRAPHICS;
 
@@ -34,25 +32,19 @@ public enum CustomerDemographicsGeneratorColumn
     CD_DEP_COLLEGE_COUNT(157, 1),
     CD_NULLS(158, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     CustomerDemographicsGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return CUSTOMER_DEMOGRAPHICS;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -65,5 +57,11 @@ public enum CustomerDemographicsGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/CustomerGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/CustomerGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.CUSTOMER;
 
@@ -43,25 +41,19 @@ public enum CustomerGeneratorColumn
     C_LAST_REVIEW_DATE(131, 1),
     C_NULLS(132, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     CustomerGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return CUSTOMER;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -74,5 +66,11 @@ public enum CustomerGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/DateDimGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/DateDimGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.DATE_DIM;
 
@@ -53,25 +51,19 @@ public enum DateDimGeneratorColumn
     D_CURRENT_YEAR(186, 0),
     D_NULLS(187, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     DateDimGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return DATE_DIM;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -84,5 +76,11 @@ public enum DateDimGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/DbgenVersionGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/DbgenVersionGeneratorColumn.java
@@ -14,8 +14,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.DBGEN_VERSION;
 
@@ -27,25 +25,19 @@ public enum DbgenVersionGeneratorColumn
     DV_CREATE_TIME(478, 1),
     DV_CMDLINE_ARGS(479, 1);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     DbgenVersionGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return DBGEN_VERSION;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -58,5 +50,11 @@ public enum DbgenVersionGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/GeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/GeneratorColumn.java
@@ -15,7 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
 
 /**
  * GeneratorColumns are columns that are used only within the context of the
@@ -27,9 +26,9 @@ public interface GeneratorColumn
 {
     Table getTable();
 
-    RandomNumberStream getRandomNumberStream();
-
     int getGlobalColumnNumber();
+
+    int getSeedsPerRow();
 
     String getName();
 }

--- a/src/main/java/com/teradata/tpcds/generator/HouseholdDemographicsGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/HouseholdDemographicsGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.HOUSEHOLD_DEMOGRAPHICS;
 
@@ -30,25 +28,19 @@ public enum HouseholdDemographicsGeneratorColumn
     HD_VEHICLE_COUNT(192, 1),
     HD_NULLS(193, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     HouseholdDemographicsGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return HOUSEHOLD_DEMOGRAPHICS;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -61,5 +53,11 @@ public enum HouseholdDemographicsGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/IncomeBandGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/IncomeBandGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.INCOME_BAND;
 
@@ -28,25 +26,19 @@ public enum IncomeBandGeneratorColumn
     IB_UPPER_BOUND(196, 1),
     IB_NULLS(197, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     IncomeBandGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return INCOME_BAND;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -59,5 +51,11 @@ public enum IncomeBandGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/InventoryGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/InventoryGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.INVENTORY;
 
@@ -29,25 +27,19 @@ public enum InventoryGeneratorColumn
     INV_QUANTITY_ON_HAND(201, 1),
     INV_NULLS(202, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     InventoryGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return INVENTORY;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -60,5 +52,11 @@ public enum InventoryGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/ItemGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/ItemGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.ITEM;
 
@@ -49,25 +47,19 @@ public enum ItemGeneratorColumn
     I_SCD(226, 1),
     I_PROMO_SK(227, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     ItemGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return ITEM;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -80,5 +72,11 @@ public enum ItemGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/PromotionGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/PromotionGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.PROMOTION;
 
@@ -44,25 +42,19 @@ public enum PromotionGeneratorColumn
     P_DISCOUNT_ACTIVE(246, 1),
     P_NULLS(247, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     PromotionGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return PROMOTION;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -75,5 +67,11 @@ public enum PromotionGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/ReasonGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/ReasonGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.REASON;
 
@@ -28,25 +26,19 @@ public enum ReasonGeneratorColumn
     R_REASON_DESCRIPTION(250, 1),
     R_NULLS(251, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     ReasonGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return REASON;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -59,5 +51,11 @@ public enum ReasonGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/ShipModeGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/ShipModeGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.SHIP_MODE;
 
@@ -31,25 +29,19 @@ public enum ShipModeGeneratorColumn
     SM_CARRIER(257, 1),
     SM_NULLS(258, 2);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     ShipModeGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return SHIP_MODE;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -62,5 +54,11 @@ public enum ShipModeGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/StoreGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/StoreGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.STORE;
 
@@ -57,25 +55,19 @@ public enum StoreGeneratorColumn
     W_STORE_SCD(290, 1),
     W_STORE_ADDRESS(291, 7);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     StoreGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return STORE;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -88,5 +80,11 @@ public enum StoreGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/StoreReturnsGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/StoreReturnsGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.STORE_RETURNS;
 
@@ -46,25 +44,19 @@ public enum StoreReturnsGeneratorColumn
     SR_PRICING(312, 80),
     SR_NULLS(313, 32);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     StoreReturnsGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return STORE_RETURNS;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -77,5 +69,11 @@ public enum StoreReturnsGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/StoreSalesGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/StoreSalesGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.STORE_SALES;
 
@@ -50,25 +48,19 @@ public enum StoreSalesGeneratorColumn
     SS_NULLS(338, 32),
     SS_PERMUTATION(339, 0);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     StoreSalesGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return STORE_SALES;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -81,5 +73,11 @@ public enum StoreSalesGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/TimeDimGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/TimeDimGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.TIME_DIM;
 
@@ -35,25 +33,19 @@ public enum TimeDimGeneratorColumn
     T_MEAL_TIME(349, 1),
     T_NULLS(350, 1);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     TimeDimGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return TIME_DIM;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -66,5 +58,11 @@ public enum TimeDimGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/WarehouseGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/WarehouseGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.WAREHOUSE;
 
@@ -40,25 +38,19 @@ public enum WarehouseGeneratorColumn
     W_NULLS(365, 2),
     W_WAREHOUSE_ADDRESS(366, 7);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     WarehouseGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return WAREHOUSE;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -71,5 +63,11 @@ public enum WarehouseGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/WebPageGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/WebPageGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.WEB_PAGE;
 
@@ -40,25 +38,19 @@ public enum WebPageGeneratorColumn
     WP_NULLS(381, 2),
     WP_SCD(382, 1);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     WebPageGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return WEB_PAGE;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -71,5 +63,11 @@ public enum WebPageGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/WebReturnsGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/WebReturnsGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.WEB_RETURNS;
 
@@ -50,25 +48,19 @@ public enum WebReturnsGeneratorColumn
     WR_PRICING(407, 80),
     WR_NULLS(408, 32);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     WebReturnsGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return WEB_RETURNS;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -81,5 +73,11 @@ public enum WebReturnsGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/WebSalesGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/WebSalesGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.WEB_SALES;
 
@@ -62,25 +60,19 @@ public enum WebSalesGeneratorColumn
     WR_IS_RETURNED(445, 16),
     WS_PERMUTATION(446, 0);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     WebSalesGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return WEB_SALES;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -93,5 +85,11 @@ public enum WebSalesGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/generator/WebSiteGeneratorColumn.java
+++ b/src/main/java/com/teradata/tpcds/generator/WebSiteGeneratorColumn.java
@@ -15,8 +15,6 @@
 package com.teradata.tpcds.generator;
 
 import com.teradata.tpcds.Table;
-import com.teradata.tpcds.random.RandomNumberStream;
-import com.teradata.tpcds.random.RandomNumberStreamImpl;
 
 import static com.teradata.tpcds.Table.WEB_SITE;
 
@@ -53,25 +51,19 @@ public enum WebSiteGeneratorColumn
     WEB_ADDRESS(474, 7),
     WEB_SCD(475, 70);
 
-    private final RandomNumberStream randomNumberStream;
     private final int globalColumnNumber;
+    private final int seedsPerRow;
 
     WebSiteGeneratorColumn(int globalColumnNumber, int seedsPerRow)
     {
         this.globalColumnNumber = globalColumnNumber;
-        this.randomNumberStream = new RandomNumberStreamImpl(globalColumnNumber, seedsPerRow);
+        this.seedsPerRow = seedsPerRow;
     }
 
     @Override
     public Table getTable()
     {
         return WEB_SITE;
-    }
-
-    @Override
-    public RandomNumberStream getRandomNumberStream()
-    {
-        return randomNumberStream;
     }
 
     @Override
@@ -84,5 +76,11 @@ public enum WebSiteGeneratorColumn
     public String getName()
     {
         return name().toLowerCase();
+    }
+
+    @Override
+    public int getSeedsPerRow()
+    {
+        return seedsPerRow;
     }
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/AbstractRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/AbstractRowGenerator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teradata.tpcds.row.generator;
+
+import com.google.common.collect.ImmutableMap;
+import com.teradata.tpcds.Table;
+import com.teradata.tpcds.generator.GeneratorColumn;
+import com.teradata.tpcds.random.RandomNumberStream;
+import com.teradata.tpcds.random.RandomNumberStreamImpl;
+
+import static com.teradata.tpcds.random.RandomValueGenerator.generateUniformRandomInt;
+
+public abstract class AbstractRowGenerator
+        implements RowGenerator
+{
+    private final ImmutableMap<GeneratorColumn, RandomNumberStream> randomNumberStreamMap;
+
+    public AbstractRowGenerator(Table table)
+    {
+        ImmutableMap.Builder<GeneratorColumn, RandomNumberStream> mapBuilder = ImmutableMap.builder();
+        for (GeneratorColumn column : table.getGeneratorColumns()) {
+            mapBuilder.put(column, new RandomNumberStreamImpl(column.getGlobalColumnNumber(), column.getSeedsPerRow()));
+        }
+        randomNumberStreamMap = mapBuilder.build();
+    }
+
+    @Override
+    public void consumeRemainingSeedsForRow()
+    {
+        for (RandomNumberStream randomNumberStream : randomNumberStreamMap.values()) {
+            while (randomNumberStream.getSeedsUsed() < randomNumberStream.getSeedsPerRow()) {
+                generateUniformRandomInt(1, 100, randomNumberStream);
+            }
+            randomNumberStream.resetSeedsUsed();
+        }
+    }
+
+    public void skipRowsUntilStartingRowNumber(long startingRowNumber)
+    {
+        for (RandomNumberStream randomNumberStream : randomNumberStreamMap.values()) {
+            randomNumberStream.skipRows((int) startingRowNumber - 1);  // casting long to int copies C code
+        }
+    }
+
+    public RandomNumberStream getRandomNumberStream(GeneratorColumn column)
+    {
+        return randomNumberStreamMap.get(column);
+    }
+}

--- a/src/main/java/com/teradata/tpcds/row/generator/CatalogPageRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CatalogPageRowGenerator.java
@@ -28,17 +28,22 @@ import static com.teradata.tpcds.type.Date.DATE_MINIMUM;
 import static com.teradata.tpcds.type.Date.JULIAN_DATA_START_DATE;
 
 public class CatalogPageRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
     public static final int CATALOGS_PER_YEAR = 18;
     private static final int WIDTH_CP_DESCRIPTION = 100;
+
+    public CatalogPageRowGenerator()
+    {
+        super(CATALOG_PAGE);
+    }
 
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         long cpCatalogPageSk = rowNumber;
         String cpDepartment = "DEPARTMENT";
-        long nullBitMap = createNullBitMap(CP_NULLS);
+        long nullBitMap = createNullBitMap(CATALOG_PAGE, getRandomNumberStream(CP_NULLS));
         String cpCatalogPageId = makeBusinessKey(rowNumber);
 
         int catalogPageMax = ((int) (session.getScaling().getRowCount(CATALOG_PAGE) / CATALOGS_PER_YEAR)) / (DATE_MAXIMUM.getYear() - DATE_MINIMUM.getYear() + 2);
@@ -72,7 +77,7 @@ public class CatalogPageRowGenerator
 
         long cpStartDateId = JULIAN_DATA_START_DATE + offset + ((cpCatalogNumber - 1) / CATALOGS_PER_YEAR) * 365;
         long cpEndDateId = cpStartDateId + duration - 1;
-        String cpDescription = generateRandomText(WIDTH_CP_DESCRIPTION / 2, WIDTH_CP_DESCRIPTION - 1, CP_DESCRIPTION.getRandomNumberStream());
+        String cpDescription = generateRandomText(WIDTH_CP_DESCRIPTION / 2, WIDTH_CP_DESCRIPTION - 1, getRandomNumberStream(CP_DESCRIPTION));
 
         return new RowGeneratorResult(new CatalogPageRow(
                 cpCatalogPageSk,
@@ -86,7 +91,4 @@ public class CatalogPageRowGenerator
                 cpType,
                 nullBitMap));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/CatalogReturnsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CatalogReturnsRowGenerator.java
@@ -24,7 +24,7 @@ import com.teradata.tpcds.type.Pricing;
 
 import static com.teradata.tpcds.JoinKeyUtils.generateJoinKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
-import static com.teradata.tpcds.Table.CATALOG_SALES;
+import static com.teradata.tpcds.Table.CATALOG_RETURNS;
 import static com.teradata.tpcds.Table.CUSTOMER;
 import static com.teradata.tpcds.Table.CUSTOMER_ADDRESS;
 import static com.teradata.tpcds.Table.CUSTOMER_DEMOGRAPHICS;
@@ -50,9 +50,14 @@ import static com.teradata.tpcds.type.Pricing.generatePricingForReturnsTable;
 import static java.util.Collections.emptyList;
 
 public class CatalogReturnsRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
     public static final int RETURN_PERCENT = 10;
+
+    public CatalogReturnsRowGenerator()
+    {
+        super(CATALOG_RETURNS);
+    }
 
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
@@ -60,7 +65,7 @@ public class CatalogReturnsRowGenerator
         // The catalog returns table is a child of the catalog_sales table because you can only return things that have
         // already been purchased.  This method should only get called if we are generating the catalog_returns table
         // in isolation. Otherwise catalog_returns is generated during the generation of the catalog_sales table
-        RowGeneratorResult salesAndReturnsResult = parentRowGenerator.generateRowAndChildRows(rowNumber, session, null , this);
+        RowGeneratorResult salesAndReturnsResult = parentRowGenerator.generateRowAndChildRows(rowNumber, session, null, this);
         if (salesAndReturnsResult.getRowAndChildRows().size() == 2) {
             return new RowGeneratorResult(ImmutableList.of(salesAndReturnsResult.getRowAndChildRows().get(1)), salesAndReturnsResult.shouldEndRow());
         }
@@ -69,20 +74,17 @@ public class CatalogReturnsRowGenerator
         }
     }
 
-    @Override
-    public void reset() {}
-
     public TableRow generateRow(Session session, CatalogSalesRow salesRow)
     {
-        long nullBitMap = createNullBitMap(CR_NULLS);
+        long nullBitMap = createNullBitMap(CATALOG_RETURNS, getRandomNumberStream(CR_NULLS));
 
         // some of the fields are conditionally taken from the sale
         Scaling scaling = session.getScaling();
-        long crReturningCustomerSk = generateJoinKey(CR_RETURNING_CUSTOMER_SK, CUSTOMER, 2, scaling);
-        long crReturningCdemoSk = generateJoinKey(CR_RETURNING_CDEMO_SK, CUSTOMER_DEMOGRAPHICS, 2, scaling);
-        long crReturningHdemoSk = generateJoinKey(CR_RETURNING_HDEMO_SK, HOUSEHOLD_DEMOGRAPHICS, 2, scaling);
-        long crReturningAddrSk = generateJoinKey(CR_RETURNING_ADDR_SK, CUSTOMER_ADDRESS, 2, scaling);
-        if (generateUniformRandomInt(0, 99, CR_RETURNING_CUSTOMER_SK.getRandomNumberStream()) < CatalogSalesRowGenerator.GIFT_PERCENTAGE) {
+        long crReturningCustomerSk = generateJoinKey(CR_RETURNING_CUSTOMER_SK, getRandomNumberStream(CR_RETURNING_CUSTOMER_SK), CUSTOMER, 2, scaling);
+        long crReturningCdemoSk = generateJoinKey(CR_RETURNING_CDEMO_SK, getRandomNumberStream(CR_RETURNING_CDEMO_SK), CUSTOMER_DEMOGRAPHICS, 2, scaling);
+        long crReturningHdemoSk = generateJoinKey(CR_RETURNING_HDEMO_SK, getRandomNumberStream(CR_RETURNING_HDEMO_SK), HOUSEHOLD_DEMOGRAPHICS, 2, scaling);
+        long crReturningAddrSk = generateJoinKey(CR_RETURNING_ADDR_SK, getRandomNumberStream(CR_RETURNING_ADDR_SK), CUSTOMER_ADDRESS, 2, scaling);
+        if (generateUniformRandomInt(0, 99, getRandomNumberStream(CR_RETURNING_CUSTOMER_SK)) < CatalogSalesRowGenerator.GIFT_PERCENTAGE) {
             crReturningCustomerSk = salesRow.getCsShipCustomerSk();
             crReturningCdemoSk = salesRow.getCsShipCdemoSk();
             // skip crReturningHdemoSk, since it doesn't exist on the sales record
@@ -92,12 +94,12 @@ public class CatalogReturnsRowGenerator
         Pricing salesPricing = salesRow.getCsPricing();
         int quantity = salesPricing.getQuantity();
         if (salesRow.getCsPricing().getQuantity() != -1) {
-            quantity = generateUniformRandomInt(1, quantity, CR_PRICING.getRandomNumberStream());
+            quantity = generateUniformRandomInt(1, quantity, getRandomNumberStream(CR_PRICING));
         }
-        Pricing crPricing = generatePricingForReturnsTable(CR_PRICING, quantity, salesPricing);
+        Pricing crPricing = generatePricingForReturnsTable(CR_PRICING, getRandomNumberStream(CR_PRICING), quantity, salesPricing);
 
-        return new CatalogReturnsRow(generateJoinKey(CR_RETURNED_DATE_SK, DATE_DIM, salesRow.getCsShipDateSk(), scaling), // items cannot be returned until  they are shipped
-                generateJoinKey(CR_RETURNED_TIME_SK, TIME_DIM, 1, scaling),
+        return new CatalogReturnsRow(generateJoinKey(CR_RETURNED_DATE_SK, getRandomNumberStream(CR_RETURNED_DATE_SK), DATE_DIM, salesRow.getCsShipDateSk(), scaling), // items cannot be returned until  they are shipped
+                generateJoinKey(CR_RETURNED_TIME_SK, getRandomNumberStream(CR_RETURNED_TIME_SK), TIME_DIM, 1, scaling),
                 salesRow.getCsSoldItemSk(),
                 salesRow.getCsBillCustomerSk(),
                 salesRow.getCsBillCdemoSk(),
@@ -109,9 +111,9 @@ public class CatalogReturnsRowGenerator
                 crReturningAddrSk,
                 salesRow.getCsCallCenterSk(),
                 salesRow.getCsCatalogPageSk(),
-                generateJoinKey(CR_SHIP_MODE_SK, SHIP_MODE, 1, scaling),
-                generateJoinKey(CR_WAREHOUSE_SK, WAREHOUSE, 1, scaling),
-                generateJoinKey(CR_REASON_SK, REASON, 1, scaling),
+                generateJoinKey(CR_SHIP_MODE_SK, getRandomNumberStream(CR_SHIP_MODE_SK), SHIP_MODE, 1, scaling),
+                generateJoinKey(CR_WAREHOUSE_SK, getRandomNumberStream(CR_WAREHOUSE_SK), WAREHOUSE, 1, scaling),
+                generateJoinKey(CR_REASON_SK, getRandomNumberStream(CR_REASON_SK), REASON, 1, scaling),
                 salesRow.getCsOrderNumber(),
                 crPricing,
                 nullBitMap);

--- a/src/main/java/com/teradata/tpcds/row/generator/CustomerAddressRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CustomerAddressRowGenerator.java
@@ -20,6 +20,7 @@ import com.teradata.tpcds.type.Address;
 
 import static com.teradata.tpcds.BusinessKeyGenerator.makeBusinessKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.CUSTOMER_ADDRESS;
 import static com.teradata.tpcds.distribution.LocationTypesDistribution.LocationTypeWeights.UNIFORM;
 import static com.teradata.tpcds.distribution.LocationTypesDistribution.pickRandomLocationType;
 import static com.teradata.tpcds.generator.CustomerAddressGeneratorColumn.CA_ADDRESS;
@@ -28,19 +29,21 @@ import static com.teradata.tpcds.generator.CustomerAddressGeneratorColumn.CA_NUL
 import static com.teradata.tpcds.type.Address.makeAddressForColumn;
 
 public class CustomerAddressRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
-    @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
+    public CustomerAddressRowGenerator()
     {
-        long nullBitMap = createNullBitMap(CA_NULLS);
-        long caAddrSk = rowNumber;
-        String caAddrId = makeBusinessKey(rowNumber);
-        Address caAddr = makeAddressForColumn(CA_ADDRESS, session.getScaling());
-        String caLocationType = pickRandomLocationType(CA_LOCATION_TYPE.getRandomNumberStream(), UNIFORM);
-        return new RowGeneratorResult(new CustomerAddressRow(nullBitMap, caAddrSk, caAddrId, caAddr, caLocationType));
+        super(CUSTOMER_ADDRESS);
     }
 
     @Override
-    public void reset() {}
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
+    {
+        long nullBitMap = createNullBitMap(CUSTOMER_ADDRESS, getRandomNumberStream(CA_NULLS));
+        long caAddrSk = rowNumber;
+        String caAddrId = makeBusinessKey(rowNumber);
+        Address caAddr = makeAddressForColumn(CUSTOMER_ADDRESS, getRandomNumberStream(CA_ADDRESS), session.getScaling());
+        String caLocationType = pickRandomLocationType(getRandomNumberStream(CA_LOCATION_TYPE), UNIFORM);
+        return new RowGeneratorResult(new CustomerAddressRow(nullBitMap, caAddrSk, caAddrId, caAddr, caLocationType));
+    }
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/CustomerDemographicsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/CustomerDemographicsRowGenerator.java
@@ -18,6 +18,7 @@ import com.teradata.tpcds.Session;
 import com.teradata.tpcds.row.CustomerDemographicsRow;
 
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.CUSTOMER_DEMOGRAPHICS;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.CREDIT_RATING_DISTRIBUTION;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.EDUCATION_DISTRIBUTION;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.GENDER_DISTRIBUTION;
@@ -31,16 +32,21 @@ import static com.teradata.tpcds.distribution.DemographicsDistributions.getPurch
 import static com.teradata.tpcds.generator.CustomerDemographicsGeneratorColumn.CD_NULLS;
 
 public class CustomerDemographicsRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
     private static final int MAX_CHILDREN = 7;
     private static final int MAX_EMPLOYED = 7;
     private static final int MAX_COLLEGE = 7;
 
+    public CustomerDemographicsRowGenerator()
+    {
+        super(CUSTOMER_DEMOGRAPHICS);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(CD_NULLS);
+        long nullBitMap = createNullBitMap(CUSTOMER_DEMOGRAPHICS, getRandomNumberStream(CD_NULLS));
         long cDemoSk = rowNumber;
         long index = cDemoSk - 1;
 
@@ -77,7 +83,4 @@ public class CustomerDemographicsRowGenerator
                 cdEmployedCount,
                 cdDepCollegeCount));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/DateDimRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/DateDimRowGenerator.java
@@ -20,6 +20,7 @@ import com.teradata.tpcds.type.Date;
 
 import static com.teradata.tpcds.BusinessKeyGenerator.makeBusinessKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.DATE_DIM;
 import static com.teradata.tpcds.distribution.CalendarDistribution.getIsHolidayFlagAtIndex;
 import static com.teradata.tpcds.distribution.CalendarDistribution.getQuarterAtIndex;
 import static com.teradata.tpcds.generator.DateDimGeneratorColumn.D_NULLS;
@@ -38,12 +39,17 @@ import static com.teradata.tpcds.type.Date.isLeapYear;
 import static com.teradata.tpcds.type.Date.toJulianDays;
 
 public class DateDimRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public DateDimRowGenerator()
+    {
+        super(DATE_DIM);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(D_NULLS);
+        long nullBitMap = createNullBitMap(DATE_DIM, getRandomNumberStream(D_NULLS));
 
         Date baseDate = new Date(1900, 1, 1);
         long dDateSk = rowNumber + toJulianDays(baseDate);
@@ -116,7 +122,4 @@ public class DateDimRowGenerator
                 dCurrentQuarter,
                 dCurrentYear));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/DbgenVersionRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/DbgenVersionRowGenerator.java
@@ -14,6 +14,7 @@
 package com.teradata.tpcds.row.generator;
 
 import com.teradata.tpcds.Session;
+import com.teradata.tpcds.Table;
 import com.teradata.tpcds.row.DbgenVersionRow;
 
 import java.text.DateFormat;
@@ -21,9 +22,14 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
 public class DbgenVersionRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
     private static final String DBGEN_VERSION = "2.0.0";
+
+    public DbgenVersionRowGenerator()
+    {
+        super(Table.DBGEN_VERSION);
+    }
 
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
@@ -39,7 +45,4 @@ public class DbgenVersionRowGenerator
                 session.getCommandLineArguments());
         return new RowGeneratorResult(row);
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/HouseholdDemographicsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/HouseholdDemographicsRowGenerator.java
@@ -18,6 +18,7 @@ import com.teradata.tpcds.Session;
 import com.teradata.tpcds.row.HouseholdDemographicsRow;
 
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.HOUSEHOLD_DEMOGRAPHICS;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.BUY_POTENTIAL_DISTRIBUTION;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.DEP_COUNT_DISTRIBUTION;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.INCOME_BAND_DISTRIBUTION;
@@ -27,12 +28,17 @@ import static com.teradata.tpcds.distribution.DemographicsDistributions.getVehic
 import static com.teradata.tpcds.generator.HouseholdDemographicsGeneratorColumn.HD_NULLS;
 
 public class HouseholdDemographicsRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public HouseholdDemographicsRowGenerator()
+    {
+        super(HOUSEHOLD_DEMOGRAPHICS);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(HD_NULLS);
+        long nullBitMap = createNullBitMap(HOUSEHOLD_DEMOGRAPHICS, getRandomNumberStream(HD_NULLS));
         long hdDemoSk = rowNumber;
         long index = hdDemoSk;
         long hdIncomeBandId = (index % INCOME_BAND_DISTRIBUTION.getSize()) + 1;
@@ -48,7 +54,4 @@ public class HouseholdDemographicsRowGenerator
 
         return new RowGeneratorResult(new HouseholdDemographicsRow(nullBitMap, hdDemoSk, hdIncomeBandId, hdBuyPotential, hdDepCount, hdVehicleCount));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/IncomeBandRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/IncomeBandRowGenerator.java
@@ -18,23 +18,26 @@ import com.teradata.tpcds.Session;
 import com.teradata.tpcds.row.IncomeBandRow;
 
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.INCOME_BAND;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.getIncomeBandLowerBoundAtIndex;
 import static com.teradata.tpcds.distribution.DemographicsDistributions.getIncomeBandUpperBoundAtIndex;
 import static com.teradata.tpcds.generator.IncomeBandGeneratorColumn.IB_NULLS;
 
 public class IncomeBandRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public IncomeBandRowGenerator()
+    {
+        super(INCOME_BAND);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(IB_NULLS);
+        long nullBitMap = createNullBitMap(INCOME_BAND, getRandomNumberStream(IB_NULLS));
         int ibIncomeBandId = (int) rowNumber;
         int ibLowerBound = getIncomeBandLowerBoundAtIndex((int) rowNumber - 1);
         int ibUpperBound = getIncomeBandUpperBoundAtIndex((int) rowNumber - 1);
         return new RowGeneratorResult(new IncomeBandRow(nullBitMap, ibIncomeBandId, ibLowerBound, ibUpperBound));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/InventoryRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/InventoryRowGenerator.java
@@ -20,6 +20,7 @@ import com.teradata.tpcds.SlowlyChangingDimensionUtils;
 import com.teradata.tpcds.row.InventoryRow;
 
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.INVENTORY;
 import static com.teradata.tpcds.Table.ITEM;
 import static com.teradata.tpcds.Table.WAREHOUSE;
 import static com.teradata.tpcds.generator.InventoryGeneratorColumn.INV_NULLS;
@@ -28,12 +29,17 @@ import static com.teradata.tpcds.random.RandomValueGenerator.generateUniformRand
 import static com.teradata.tpcds.type.Date.JULIAN_DATE_MINIMUM;
 
 public class InventoryRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public InventoryRowGenerator()
+    {
+        super(INVENTORY);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(INV_NULLS);
+        long nullBitMap = createNullBitMap(INVENTORY, getRandomNumberStream(INV_NULLS));
         int index = (int) rowNumber - 1;
         Scaling scaling = session.getScaling();
         long itemCount = scaling.getIdCount(ITEM);
@@ -52,11 +58,8 @@ public class InventoryRowGenerator
         // but item is a slowly changing dimension, so we need to account for that in selecting the surrogate key to join with
         invItemSk = SlowlyChangingDimensionUtils.matchSurrogateKey(invItemSk, invDateSk, ITEM, scaling);
 
-        int invQuantityOnHand = generateUniformRandomInt(0, 1000, INV_QUANTITY_ON_HAND.getRandomNumberStream());
+        int invQuantityOnHand = generateUniformRandomInt(0, 1000, getRandomNumberStream(INV_QUANTITY_ON_HAND));
 
         return new RowGeneratorResult(new InventoryRow(nullBitMap, invDateSk, invItemSk, invWarehouseSk, invQuantityOnHand));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/PromotionRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/PromotionRowGenerator.java
@@ -22,6 +22,7 @@ import com.teradata.tpcds.type.Decimal;
 import static com.teradata.tpcds.BusinessKeyGenerator.makeBusinessKey;
 import static com.teradata.tpcds.JoinKeyUtils.generateJoinKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.PROMOTION;
 import static com.teradata.tpcds.distribution.EnglishDistributions.SYLLABLES_DISTRIBUTION;
 import static com.teradata.tpcds.generator.PromotionGeneratorColumn.P_CHANNEL_DETAILS;
 import static com.teradata.tpcds.generator.PromotionGeneratorColumn.P_CHANNEL_DMAIL;
@@ -35,7 +36,7 @@ import static com.teradata.tpcds.random.RandomValueGenerator.generateWord;
 import static com.teradata.tpcds.type.Date.JULIAN_DATE_MINIMUM;
 
 public class PromotionRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
     private static final int PROMO_START_MIN = -720;
     private static final int PROMO_START_MAX = 100;
@@ -45,22 +46,27 @@ public class PromotionRowGenerator
     private static final int PROMO_DETAIL_LENGTH_MIN = 20;
     private static final int PROMO_DETAIL_LENGTH_MAX = 60;
 
+    public PromotionRowGenerator()
+    {
+        super(PROMOTION);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(P_NULLS);
+        long nullBitMap = createNullBitMap(PROMOTION, getRandomNumberStream(P_NULLS));
         long pPromoSk = rowNumber;
         String pPromoId = makeBusinessKey(rowNumber);
-        long pStartDateId = JULIAN_DATE_MINIMUM + generateUniformRandomInt(PROMO_START_MIN, PROMO_START_MAX, P_START_DATE_ID.getRandomNumberStream());
-        long pEndDateId = pStartDateId + generateUniformRandomInt(PROMO_LENGTH_MIN, PROMO_LENGTH_MAX, P_END_DATE_ID.getRandomNumberStream());
+        long pStartDateId = JULIAN_DATE_MINIMUM + generateUniformRandomInt(PROMO_START_MIN, PROMO_START_MAX, getRandomNumberStream(P_START_DATE_ID));
+        long pEndDateId = pStartDateId + generateUniformRandomInt(PROMO_LENGTH_MIN, PROMO_LENGTH_MAX, getRandomNumberStream(P_END_DATE_ID));
 
-        long pItemSk = generateJoinKey(P_ITEM_SK, Table.ITEM, 1, session.getScaling());
+        long pItemSk = generateJoinKey(P_ITEM_SK, getRandomNumberStream(P_ITEM_SK), Table.ITEM, 1, session.getScaling());
 
         Decimal pCost = new Decimal(100000, 2);
         int pResponseTarget = 1;
         String pPromoName = generateWord(rowNumber, PROMO_NAME_LENGTH, SYLLABLES_DISTRIBUTION);
 
-        int flags = generateUniformRandomInt(0, 511, P_CHANNEL_DMAIL.getRandomNumberStream());
+        int flags = generateUniformRandomInt(0, 511, getRandomNumberStream(P_CHANNEL_DMAIL));
         boolean pChannelDmail = (flags & 0x01) != 0;
         flags <<= 1;
 
@@ -87,7 +93,7 @@ public class PromotionRowGenerator
 
         boolean pDiscountActive = (flags & 0x01) != 0;
 
-        String pChannelDetails = generateRandomText(PROMO_DETAIL_LENGTH_MIN, PROMO_DETAIL_LENGTH_MAX, P_CHANNEL_DETAILS.getRandomNumberStream());
+        String pChannelDetails = generateRandomText(PROMO_DETAIL_LENGTH_MIN, PROMO_DETAIL_LENGTH_MAX, getRandomNumberStream(P_CHANNEL_DETAILS));
 
         String pPurpose = "Unknown";
 
@@ -112,7 +118,4 @@ public class PromotionRowGenerator
                 pPurpose,
                 pDiscountActive));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/ReasonRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/ReasonRowGenerator.java
@@ -19,23 +19,26 @@ import com.teradata.tpcds.row.ReasonRow;
 
 import static com.teradata.tpcds.BusinessKeyGenerator.makeBusinessKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.REASON;
 import static com.teradata.tpcds.distribution.ReturnReasonsDistribution.getReturnReasonAtIndex;
 import static com.teradata.tpcds.generator.ReasonGeneratorColumn.R_NULLS;
 
 public class ReasonRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public ReasonRowGenerator()
+    {
+        super(REASON);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(R_NULLS);
+        long nullBitMap = createNullBitMap(REASON, getRandomNumberStream(R_NULLS));
         long rReasonSk = rowNumber;
         String rReasonId = makeBusinessKey(rowNumber);
         String rReasonDescription = getReturnReasonAtIndex((int) (rowNumber - 1));
 
         return new RowGeneratorResult(new ReasonRow(nullBitMap, rReasonSk, rReasonId, rReasonDescription));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/RowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/RowGenerator.java
@@ -20,5 +20,7 @@ public interface RowGenerator
 {
     RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator);
 
-    void reset();
+    void consumeRemainingSeedsForRow();
+
+    void skipRowsUntilStartingRowNumber(long startingRowNumber);
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/ShipModeRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/ShipModeRowGenerator.java
@@ -19,6 +19,7 @@ import com.teradata.tpcds.row.ShipModeRow;
 
 import static com.teradata.tpcds.BusinessKeyGenerator.makeBusinessKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.SHIP_MODE;
 import static com.teradata.tpcds.distribution.ShipModeDistributions.SHIP_MODE_TYPE_DISTRIBUTION;
 import static com.teradata.tpcds.distribution.ShipModeDistributions.getShipModeCarrierAtIndex;
 import static com.teradata.tpcds.distribution.ShipModeDistributions.getShipModeCodeForIndexModSize;
@@ -29,12 +30,17 @@ import static com.teradata.tpcds.random.RandomValueGenerator.ALPHA_NUMERIC;
 import static com.teradata.tpcds.random.RandomValueGenerator.generateRandomCharset;
 
 public class ShipModeRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public ShipModeRowGenerator()
+    {
+        super(SHIP_MODE);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(SM_NULLS);
+        long nullBitMap = createNullBitMap(SHIP_MODE, getRandomNumberStream(SM_NULLS));
         long smShipModeSk = rowNumber;
         String smShipModeId = makeBusinessKey(rowNumber);
 
@@ -47,11 +53,8 @@ public class ShipModeRowGenerator
 
         String smCarrier = getShipModeCarrierAtIndex((int) (rowNumber) - 1);
 
-        String smContract = generateRandomCharset(ALPHA_NUMERIC, 1, 20, SM_CONTRACT.getRandomNumberStream());
+        String smContract = generateRandomCharset(ALPHA_NUMERIC, 1, 20, getRandomNumberStream(SM_CONTRACT));
 
         return new RowGeneratorResult(new ShipModeRow(nullBitMap, smShipModeSk, smShipModeId, smType, smCode, smCarrier, smContract));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/StoreSalesRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/StoreSalesRowGenerator.java
@@ -38,7 +38,6 @@ import static com.teradata.tpcds.Table.HOUSEHOLD_DEMOGRAPHICS;
 import static com.teradata.tpcds.Table.ITEM;
 import static com.teradata.tpcds.Table.PROMOTION;
 import static com.teradata.tpcds.Table.STORE;
-import static com.teradata.tpcds.Table.STORE_RETURNS;
 import static com.teradata.tpcds.Table.STORE_SALES;
 import static com.teradata.tpcds.Table.TIME_DIM;
 import static com.teradata.tpcds.generator.StoreSalesGeneratorColumn.SR_IS_RETURNED;
@@ -59,7 +58,7 @@ import static com.teradata.tpcds.random.RandomValueGenerator.generateUniformRand
 import static com.teradata.tpcds.type.Pricing.generatePricingForSalesTable;
 
 public class StoreSalesRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
     private static final int SR_RETURN_PCT = 10;
 
@@ -71,12 +70,17 @@ public class StoreSalesRowGenerator
     private OrderInfo orderInfo = new OrderInfo();
     private int itemIndex;
 
+    public StoreSalesRowGenerator()
+    {
+        super(STORE_SALES);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
         int itemCount = (int) session.getScaling().getIdCount(ITEM);
         if (itemPermutation == null) {
-            itemPermutation = makePermutation(itemCount, SS_PERMUTATION.getRandomNumberStream());
+            itemPermutation = makePermutation(itemCount, getRandomNumberStream(SS_PERMUTATION));
             Parallel.DateNextIndexPair pair = skipDaysUntilFirstRowOfChunk(STORE_SALES, session);
             julianDate = pair.getJulianDate();
             nextDateIndex = pair.getNextDateIndex();
@@ -85,11 +89,11 @@ public class StoreSalesRowGenerator
         Scaling scaling = session.getScaling();
         if (remainingLineItems == 0) {
             orderInfo = generateOrderInfo(rowNumber, session);
-            remainingLineItems = generateUniformRandomInt(8, 16, SS_TICKET_NUMBER.getRandomNumberStream());
-            itemIndex = generateUniformRandomInt(1, (int) scaling.getIdCount(ITEM), SS_SOLD_ITEM_SK.getRandomNumberStream());
+            remainingLineItems = generateUniformRandomInt(8, 16, getRandomNumberStream(SS_TICKET_NUMBER));
+            itemIndex = generateUniformRandomInt(1, (int) scaling.getIdCount(ITEM), getRandomNumberStream(SS_SOLD_ITEM_SK));
         }
 
-        long nullBitMap = createNullBitMap(SS_NULLS);
+        long nullBitMap = createNullBitMap(STORE_SALES, getRandomNumberStream(SS_NULLS));
 
         //items need to be unique within an order
         // use a sequence within the permutation
@@ -98,8 +102,8 @@ public class StoreSalesRowGenerator
         }
 
         long ssSoldItemSk = matchSurrogateKey(getPermutationEntry(itemPermutation, itemIndex), orderInfo.getSsSoldDateSk(), ITEM, scaling);
-        long ssSoldPromoSk = generateJoinKey(SS_SOLD_PROMO_SK, PROMOTION, 1, scaling);
-        Pricing ssPricing = generatePricingForSalesTable(SS_PRICING);
+        long ssSoldPromoSk = generateJoinKey(SS_SOLD_PROMO_SK, getRandomNumberStream(SS_SOLD_PROMO_SK), PROMOTION, 1, scaling);
+        Pricing ssPricing = generatePricingForSalesTable(SS_PRICING, getRandomNumberStream(SS_PRICING));
 
         StoreSalesRow storeSalesRow = new StoreSalesRow(nullBitMap,
                 orderInfo.getSsSoldDateSk(),
@@ -117,7 +121,7 @@ public class StoreSalesRowGenerator
         generatedRows.add(storeSalesRow);
 
         // if the sale gets returned, generate a return row
-        int randomInt = generateUniformRandomInt(0, 99, SR_IS_RETURNED.getRandomNumberStream());
+        int randomInt = generateUniformRandomInt(0, 99, getRandomNumberStream(SR_IS_RETURNED));
         if (randomInt < SR_RETURN_PCT && (!session.generateOnlyOneTable() || session.getOnlyTableToGenerate() != STORE_SALES)) {
             generatedRows.add(((StoreReturnsRowGenerator) childRowGenerator).generateRow(session, storeSalesRow));
         }
@@ -135,13 +139,13 @@ public class StoreSalesRowGenerator
             nextDateIndex += scaling.getRowCountForDate(STORE_SALES, julianDate);
         }
 
-        long ssSoldStoreSk = generateJoinKey(SS_SOLD_STORE_SK, STORE, 1, scaling);
-        long ssSoldTimeSk = generateJoinKey(SS_SOLD_TIME_SK, TIME_DIM, 1, scaling);
-        long ssSoldDateSk = generateJoinKey(SS_SOLD_DATE_SK, DATE_DIM, 1, scaling);
-        long ssSoldCustomerSk = generateJoinKey(SS_SOLD_CUSTOMER_SK, CUSTOMER, 1, scaling);
-        long ssSoldCdemoSk = generateJoinKey(SS_SOLD_CDEMO_SK, CUSTOMER_DEMOGRAPHICS, 1, scaling);
-        long ssSoldHdemoSk = generateJoinKey(SS_SOLD_HDEMO_SK, HOUSEHOLD_DEMOGRAPHICS, 1, scaling);
-        long ssSoldAddrSk = generateJoinKey(SS_SOLD_ADDR_SK, CUSTOMER_ADDRESS, 1, scaling);
+        long ssSoldStoreSk = generateJoinKey(SS_SOLD_STORE_SK, getRandomNumberStream(SS_SOLD_STORE_SK), STORE, 1, scaling);
+        long ssSoldTimeSk = generateJoinKey(SS_SOLD_TIME_SK, getRandomNumberStream(SS_SOLD_TIME_SK), TIME_DIM, 1, scaling);
+        long ssSoldDateSk = generateJoinKey(SS_SOLD_DATE_SK, getRandomNumberStream(SS_SOLD_DATE_SK), DATE_DIM, 1, scaling);
+        long ssSoldCustomerSk = generateJoinKey(SS_SOLD_CUSTOMER_SK, getRandomNumberStream(SS_SOLD_CUSTOMER_SK), CUSTOMER, 1, scaling);
+        long ssSoldCdemoSk = generateJoinKey(SS_SOLD_CDEMO_SK, getRandomNumberStream(SS_SOLD_CDEMO_SK), CUSTOMER_DEMOGRAPHICS, 1, scaling);
+        long ssSoldHdemoSk = generateJoinKey(SS_SOLD_HDEMO_SK, getRandomNumberStream(SS_SOLD_HDEMO_SK), HOUSEHOLD_DEMOGRAPHICS, 1, scaling);
+        long ssSoldAddrSk = generateJoinKey(SS_SOLD_ADDR_SK, getRandomNumberStream(SS_SOLD_ADDR_SK), CUSTOMER_ADDRESS, 1, scaling);
         long ssTicketNumber = rowNumber;
 
         return new OrderInfo(ssSoldStoreSk,
@@ -157,17 +161,6 @@ public class StoreSalesRowGenerator
     private boolean isLastRowInOrder()
     {
         return remainingLineItems == 0;
-    }
-
-    @Override
-    public void reset()
-    {
-        itemPermutation = null;
-        julianDate = 0;
-        nextDateIndex = 0;
-        orderInfo = new OrderInfo();
-        remainingLineItems = 0;
-        itemIndex = 0;
     }
 
     private class OrderInfo

--- a/src/main/java/com/teradata/tpcds/row/generator/TimeDimRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/TimeDimRowGenerator.java
@@ -20,16 +20,22 @@ import com.teradata.tpcds.row.TimeDimRow;
 
 import static com.teradata.tpcds.BusinessKeyGenerator.makeBusinessKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.TIME_DIM;
 import static com.teradata.tpcds.distribution.HoursDistribution.getHourInfoForHour;
 import static com.teradata.tpcds.generator.TimeDimGeneratorColumn.T_NULLS;
 
 public class TimeDimRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public TimeDimRowGenerator()
+    {
+        super(TIME_DIM);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(T_NULLS);
+        long nullBitMap = createNullBitMap(TIME_DIM, getRandomNumberStream(T_NULLS));
         long tTimeSk = rowNumber - 1;
         String tTimeId = makeBusinessKey(rowNumber);
         int tTime = (int) (rowNumber - 1);
@@ -48,7 +54,4 @@ public class TimeDimRowGenerator
 
         return new RowGeneratorResult(new TimeDimRow(nullBitMap, tTimeSk, tTimeId, tTime, tHour, tMinute, tSecond, tAmPm, tShift, tSubShift, tMealTime));
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/WarehouseRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WarehouseRowGenerator.java
@@ -20,6 +20,7 @@ import com.teradata.tpcds.type.Address;
 
 import static com.teradata.tpcds.BusinessKeyGenerator.makeBusinessKey;
 import static com.teradata.tpcds.Nulls.createNullBitMap;
+import static com.teradata.tpcds.Table.WAREHOUSE;
 import static com.teradata.tpcds.generator.WarehouseGeneratorColumn.W_NULLS;
 import static com.teradata.tpcds.generator.WarehouseGeneratorColumn.W_WAREHOUSE_ADDRESS;
 import static com.teradata.tpcds.generator.WarehouseGeneratorColumn.W_WAREHOUSE_NAME;
@@ -29,21 +30,23 @@ import static com.teradata.tpcds.random.RandomValueGenerator.generateUniformRand
 import static com.teradata.tpcds.type.Address.makeAddressForColumn;
 
 public class WarehouseRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
-    @Override
-    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
+    public WarehouseRowGenerator()
     {
-        long nullBitMap = createNullBitMap(W_NULLS);
-        long wWarehouseSk = rowNumber;
-        String wWarehouseId = makeBusinessKey(rowNumber);
-        String wWarehouseName = generateRandomText(10, 20, W_WAREHOUSE_NAME.getRandomNumberStream());
-        int wWarehouseSqFt = generateUniformRandomInt(50000, 1000000, W_WAREHOUSE_SQ_FT.getRandomNumberStream());
-        Address wAddress = makeAddressForColumn(W_WAREHOUSE_ADDRESS, session.getScaling());
-
-        return new RowGeneratorResult(new WarehouseRow(nullBitMap, wWarehouseSk, wWarehouseId, wWarehouseName, wWarehouseSqFt, wAddress));
+        super(WAREHOUSE);
     }
 
     @Override
-    public void reset() {}
+    public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
+    {
+        long nullBitMap = createNullBitMap(WAREHOUSE, getRandomNumberStream(W_NULLS));
+        long wWarehouseSk = rowNumber;
+        String wWarehouseId = makeBusinessKey(rowNumber);
+        String wWarehouseName = generateRandomText(10, 20, getRandomNumberStream(W_WAREHOUSE_NAME));
+        int wWarehouseSqFt = generateUniformRandomInt(50000, 1000000, getRandomNumberStream(W_WAREHOUSE_SQ_FT));
+        Address wAddress = makeAddressForColumn(WAREHOUSE, getRandomNumberStream(W_WAREHOUSE_ADDRESS), session.getScaling());
+
+        return new RowGeneratorResult(new WarehouseRow(nullBitMap, wWarehouseSk, wWarehouseId, wWarehouseName, wWarehouseSqFt, wAddress));
+    }
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/WebReturnsRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WebReturnsRowGenerator.java
@@ -30,7 +30,7 @@ import static com.teradata.tpcds.Table.DATE_DIM;
 import static com.teradata.tpcds.Table.HOUSEHOLD_DEMOGRAPHICS;
 import static com.teradata.tpcds.Table.REASON;
 import static com.teradata.tpcds.Table.TIME_DIM;
-import static com.teradata.tpcds.Table.WEB_SALES;
+import static com.teradata.tpcds.Table.WEB_RETURNS;
 import static com.teradata.tpcds.generator.WebReturnsGeneratorColumn.WR_NULLS;
 import static com.teradata.tpcds.generator.WebReturnsGeneratorColumn.WR_PRICING;
 import static com.teradata.tpcds.generator.WebReturnsGeneratorColumn.WR_REASON_SK;
@@ -46,8 +46,13 @@ import static com.teradata.tpcds.type.Pricing.generatePricingForReturnsTable;
 import static java.util.Collections.emptyList;
 
 public class WebReturnsRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
+    public WebReturnsRowGenerator()
+    {
+        super(WEB_RETURNS);
+    }
+
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
@@ -62,7 +67,7 @@ public class WebReturnsRowGenerator
 
     public WebReturnsRow generateRow(Session session, WebSalesRow salesRow)
     {
-        long nullBitMap = createNullBitMap(WR_NULLS);
+        long nullBitMap = createNullBitMap(WEB_RETURNS, getRandomNumberStream(WR_NULLS));
 
         // fields taken from the original sale
         long wrItemSk = salesRow.getWsItemSk();
@@ -71,15 +76,15 @@ public class WebReturnsRowGenerator
 
         // remaining fields are specific to this return
         Scaling scaling = session.getScaling();
-        long wrReturnedDateSk = generateJoinKey(WR_RETURNED_DATE_SK, DATE_DIM, salesRow.getWsShipDateSk(), scaling);
-        long wrReturnedTimeSk = generateJoinKey(WR_RETURNED_TIME_SK, TIME_DIM, 1, scaling);
+        long wrReturnedDateSk = generateJoinKey(WR_RETURNED_DATE_SK, getRandomNumberStream(WR_RETURNED_DATE_SK), DATE_DIM, salesRow.getWsShipDateSk(), scaling);
+        long wrReturnedTimeSk = generateJoinKey(WR_RETURNED_TIME_SK, getRandomNumberStream(WR_RETURNED_TIME_SK), TIME_DIM, 1, scaling);
 
         // items are usually returned to the people they were shipped to, but sometimes not
-        long wrRefundedCustomerSk = generateJoinKey(WR_REFUNDED_CUSTOMER_SK, CUSTOMER, 1, scaling);
-        long wrRefundedCdemoSk = generateJoinKey(WR_REFUNDED_CDEMO_SK, CUSTOMER_DEMOGRAPHICS, 1, scaling);
-        long wrRefundedHdemoSk = generateJoinKey(WR_REFUNDED_HDEMO_SK, HOUSEHOLD_DEMOGRAPHICS, 1, scaling);
-        long wrRefundedAddrSk = generateJoinKey(WR_REFUNDED_ADDR_SK, CUSTOMER_ADDRESS, 1, scaling);
-        if (generateUniformRandomInt(0, 99, WR_RETURNING_CUSTOMER_SK.getRandomNumberStream()) < WebSalesRowGenerator.GIFT_PERCENTAGE) {
+        long wrRefundedCustomerSk = generateJoinKey(WR_REFUNDED_CUSTOMER_SK, getRandomNumberStream(WR_REFUNDED_CUSTOMER_SK), CUSTOMER, 1, scaling);
+        long wrRefundedCdemoSk = generateJoinKey(WR_REFUNDED_CDEMO_SK, getRandomNumberStream(WR_REFUNDED_CDEMO_SK), CUSTOMER_DEMOGRAPHICS, 1, scaling);
+        long wrRefundedHdemoSk = generateJoinKey(WR_REFUNDED_HDEMO_SK, getRandomNumberStream(WR_REFUNDED_HDEMO_SK), HOUSEHOLD_DEMOGRAPHICS, 1, scaling);
+        long wrRefundedAddrSk = generateJoinKey(WR_REFUNDED_ADDR_SK, getRandomNumberStream(WR_REFUNDED_ADDR_SK), CUSTOMER_ADDRESS, 1, scaling);
+        if (generateUniformRandomInt(0, 99, getRandomNumberStream(WR_RETURNING_CUSTOMER_SK)) < WebSalesRowGenerator.GIFT_PERCENTAGE) {
             wrRefundedCustomerSk = salesRow.getWsShipCustomerSk();
             wrRefundedCdemoSk = salesRow.getWsShipCdemoSk();
             wrRefundedHdemoSk = salesRow.getWsShipHdemoSk();
@@ -91,9 +96,9 @@ public class WebReturnsRowGenerator
         long wrReturningHdemoSk = wrRefundedHdemoSk;
         long wrReturningAddrSk = wrRefundedAddrSk;
 
-        long wrReasonSk = generateJoinKey(WR_REASON_SK, REASON, 1, scaling);
-        int quantity = generateUniformRandomInt(1, salesRow.getWsPricing().getQuantity(), WR_PRICING.getRandomNumberStream());
-        Pricing wrPricing = generatePricingForReturnsTable(WR_PRICING, quantity, salesRow.getWsPricing());
+        long wrReasonSk = generateJoinKey(WR_REASON_SK, getRandomNumberStream(WR_REASON_SK), REASON, 1, scaling);
+        int quantity = generateUniformRandomInt(1, salesRow.getWsPricing().getQuantity(), getRandomNumberStream(WR_PRICING));
+        Pricing wrPricing = generatePricingForReturnsTable(WR_PRICING, getRandomNumberStream(WR_PRICING), quantity, salesRow.getWsPricing());
 
         return new WebReturnsRow(nullBitMap,
                 wrReturnedDateSk,
@@ -112,7 +117,4 @@ public class WebReturnsRowGenerator
                 wrOrderNumber,
                 wrPricing);
     }
-
-    @Override
-    public void reset() {}
 }

--- a/src/main/java/com/teradata/tpcds/row/generator/WebSiteRowGenerator.java
+++ b/src/main/java/com/teradata/tpcds/row/generator/WebSiteRowGenerator.java
@@ -59,14 +59,19 @@ import static java.lang.String.format;
 
 @NotThreadSafe
 public class WebSiteRowGenerator
-        implements RowGenerator
+        extends AbstractRowGenerator
 {
     private Optional<WebSiteRow> previousRow = Optional.empty();
+
+    public WebSiteRowGenerator()
+    {
+        super(WEB_SITE);
+    }
 
     @Override
     public RowGeneratorResult generateRowAndChildRows(long rowNumber, Session session, RowGenerator parentRowGenerator, RowGenerator childRowGenerator)
     {
-        long nullBitMap = createNullBitMap(WEB_NULLS);
+        long nullBitMap = createNullBitMap(WEB_SITE, getRandomNumberStream(WEB_NULLS));
         long webSiteSk = rowNumber;
         String webClass = "Unknown";
 
@@ -81,8 +86,8 @@ public class WebSiteRowGenerator
         long webCloseDate;
         String webName;
         if (isNewBusinessKey) {
-            webOpenDate = generateJoinKey(WEB_OPEN_DATE, DATE_DIM, rowNumber, scaling);
-            webCloseDate = generateJoinKey(WEB_CLOSE_DATE, DATE_DIM, rowNumber, scaling);
+            webOpenDate = generateJoinKey(WEB_OPEN_DATE, getRandomNumberStream(WEB_OPEN_DATE), DATE_DIM, rowNumber, scaling);
+            webCloseDate = generateJoinKey(WEB_CLOSE_DATE, getRandomNumberStream(WEB_CLOSE_DATE), DATE_DIM, rowNumber, scaling);
             if (webCloseDate > webRecEndDateId) {
                 webCloseDate = -1;
             }
@@ -96,43 +101,43 @@ public class WebSiteRowGenerator
         }
 
         // controls whether a field changes from one row to the next
-        int fieldChangeFlags = (int) WEB_SCD.getRandomNumberStream().nextRandom();
+        int fieldChangeFlags = (int) getRandomNumberStream(WEB_SCD).nextRandom();
 
-        String firstName = pickRandomFirstName(session.isSexist() ? MALE_FREQUENCY : GENERAL_FREQUENCY, WEB_MANAGER.getRandomNumberStream());
-        String lastName = pickRandomLastName(WEB_MANAGER.getRandomNumberStream());
+        String firstName = pickRandomFirstName(session.isSexist() ? MALE_FREQUENCY : GENERAL_FREQUENCY, getRandomNumberStream(WEB_MANAGER));
+        String lastName = pickRandomLastName(getRandomNumberStream(WEB_MANAGER));
         String webManager = format("%s %s", firstName, lastName);
         if (previousRow.isPresent()) {
             webManager = getValueForSlowlyChangingDimension(fieldChangeFlags, isNewBusinessKey, previousRow.get().getWebManager(), webManager);
         }
         fieldChangeFlags >>= 1;
 
-        int webMarketId = generateUniformRandomInt(1, 6, WEB_MARKET_ID.getRandomNumberStream());
+        int webMarketId = generateUniformRandomInt(1, 6, getRandomNumberStream(WEB_MARKET_ID));
         if (previousRow.isPresent()) {
             webMarketId = getValueForSlowlyChangingDimension(fieldChangeFlags, isNewBusinessKey, previousRow.get().getWebMarketId(), webMarketId);
         }
         fieldChangeFlags >>= 1;
 
-        String webMarketClass = generateRandomText(20, 50, WEB_MARKET_CLASS.getRandomNumberStream());
+        String webMarketClass = generateRandomText(20, 50, getRandomNumberStream(WEB_MARKET_CLASS));
         if (previousRow.isPresent()) {
             webMarketClass = getValueForSlowlyChangingDimension(fieldChangeFlags, isNewBusinessKey, previousRow.get().getWebMarketClass(), webMarketClass);
         }
         fieldChangeFlags >>= 1;
 
-        String webMarketDesc = generateRandomText(20, 100, WEB_MARKET_DESC.getRandomNumberStream());
+        String webMarketDesc = generateRandomText(20, 100, getRandomNumberStream(WEB_MARKET_DESC));
         if (previousRow.isPresent()) {
             webMarketDesc = getValueForSlowlyChangingDimension(fieldChangeFlags, isNewBusinessKey, previousRow.get().getWebMarketDesc(), webMarketDesc);
         }
         fieldChangeFlags >>= 1;
 
-        firstName = pickRandomFirstName(session.isSexist() ? MALE_FREQUENCY : GENERAL_FREQUENCY, WEB_MARKET_MANAGER.getRandomNumberStream());
-        lastName = pickRandomLastName(WEB_MARKET_MANAGER.getRandomNumberStream());
+        firstName = pickRandomFirstName(session.isSexist() ? MALE_FREQUENCY : GENERAL_FREQUENCY, getRandomNumberStream(WEB_MARKET_MANAGER));
+        lastName = pickRandomLastName(getRandomNumberStream(WEB_MARKET_MANAGER));
         String webMarketManager = format("%s %s", firstName, lastName);
         if (previousRow.isPresent()) {
             webMarketManager = getValueForSlowlyChangingDimension(fieldChangeFlags, isNewBusinessKey, previousRow.get().getWebMarketManager(), webMarketManager);
         }
         fieldChangeFlags >>= 1;
 
-        int webCompanyId = generateUniformRandomInt(1, 6, WEB_COMPANY_ID.getRandomNumberStream());
+        int webCompanyId = generateUniformRandomInt(1, 6, getRandomNumberStream(WEB_COMPANY_ID));
         if (previousRow.isPresent()) {
             webCompanyId = getValueForSlowlyChangingDimension(fieldChangeFlags, isNewBusinessKey, previousRow.get().getWebCompanyId(), webCompanyId);
         }
@@ -144,7 +149,7 @@ public class WebSiteRowGenerator
         }
         fieldChangeFlags >>= 1;
 
-        Address webAddress = makeAddressForColumn(WEB_ADDRESS, scaling);
+        Address webAddress = makeAddressForColumn(WEB_SITE, getRandomNumberStream(WEB_ADDRESS), scaling);
 
         // some of the fields of address always use a new value due to a bug in the C code, but we still need to update the fieldChangeFlags
         fieldChangeFlags >>= 1; // city
@@ -185,7 +190,7 @@ public class WebSiteRowGenerator
                 zip,
                 gmtOffset);
 
-        Decimal webTaxPercentage = generateUniformRandomDecimal(ZERO, new Decimal(12, 2), WEB_TAX_PERCENTAGE.getRandomNumberStream());
+        Decimal webTaxPercentage = generateUniformRandomDecimal(ZERO, new Decimal(12, 2), getRandomNumberStream(WEB_TAX_PERCENTAGE));
         if (previousRow.isPresent()) {
             webTaxPercentage = getValueForSlowlyChangingDimension(fieldChangeFlags, isNewBusinessKey, previousRow.get().getWebTaxPercentage(), webTaxPercentage);
         }
@@ -211,11 +216,5 @@ public class WebSiteRowGenerator
 
         previousRow = Optional.of(row);
         return new RowGeneratorResult(row);
-    }
-
-    @Override
-    public void reset()
-    {
-        previousRow = Optional.empty();
     }
 }

--- a/src/main/java/com/teradata/tpcds/type/Address.java
+++ b/src/main/java/com/teradata/tpcds/type/Address.java
@@ -17,7 +17,6 @@ package com.teradata.tpcds.type;
 import com.teradata.tpcds.Scaling;
 import com.teradata.tpcds.Table;
 import com.teradata.tpcds.distribution.FipsCountyDistribution;
-import com.teradata.tpcds.generator.GeneratorColumn;
 import com.teradata.tpcds.random.RandomNumberStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -86,10 +85,9 @@ public class Address
         this.gmtOffset = gmtOffset;
     }
 
-    public static Address makeAddressForColumn(GeneratorColumn column, Scaling scaling)
+    public static Address makeAddressForColumn(Table table, RandomNumberStream randomNumberStream, Scaling scaling)
     {
         AddressBuilder builder = new AddressBuilder();
-        RandomNumberStream randomNumberStream = column.getRandomNumberStream();
         builder.setStreetNumber(generateUniformRandomInt(1, 1000, randomNumberStream));
         builder.setStreetName1(pickRandomStreetName(DEFAULT, randomNumberStream));
         builder.setStreetName2(pickRandomStreetName(HALF_EMPTY, randomNumberStream));
@@ -103,8 +101,7 @@ public class Address
             builder.setSuiteNumber(format("Suite %c", ((randomInt / 2) % 25) + 'A'));
         }
 
-        Table table = column.getTable();
-        int rowCount = (int) scaling.getRowCount(column.getTable());
+        int rowCount = (int) scaling.getRowCount(table);
         String city;
         if ((table.isSmall())) {
             int maxCities = (int) ACTIVE_CITIES.getRowCountForScale(scaling.getScale());
@@ -112,7 +109,7 @@ public class Address
             city = getCityAtIndex(randomInt);
         }
         else {
-            city = pickRandomCity(UNIFIED_STEP_FUNCTION, column.getRandomNumberStream());
+            city = pickRandomCity(UNIFIED_STEP_FUNCTION, randomNumberStream);
         }
         builder.setCity(city);
 


### PR DESCRIPTION
RandomNumberStream objects must be unique to the result set that they
are generating so that concurrent table generations don't affect each
other's results


@petroav 
I apologize for the size of this PR.  It couldn't really be split up into commits that could compile on their own.  But here's a brief tour of what's going on so it's easier to follow.
1. remove RandomNumberStream from the GeneratorColumns and replace it with seedsPerRow
2. Have all the RowGenerators extend AbstractRowGenerator.  AbstractRowGenerator's constructor takes a table, and from there creates a RandomNumberStream for each column in the table and puts it in a map
3. everything that used to call GeneratorColumn.getRandomNumberStream() now calls getRandomNumberStream(GeneratorColumn) to retrieve the column from the map.  
4. There were a number of methods that took a column as an argument and in the method went and grabbed the RandomNumberStream from it (createNullBitMap(), makeAddressForColumn() generatePricingFor<Sales|Returns>Table(), generateJoinKey()).  These needed to be changed to take a RandomNumberStream directly.  This obviously affects all callers as well. 
5. Remove all reset methods.  not relevant anymore since the RowGenerators and RandomNumberStreams are no longer reused.