### PR TITLE
Avoid running the tests twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: java
 jdk:
     - oraclejdk8
-install: mvn clean install


### PR DESCRIPTION
Default set of Travis settings for java is

```
install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
script: mvn test
```

(https://docs.travis-ci.com/user/languages/java#Projects-Using-Maven)

Overriding the `install` step to

```
install: mvn clean install
```

made the tests run twice, adding ~500 s of build time.
This commit reverts to Travis defaults.
