### PR TITLE
Invert logic of --terminate option

### DIFF
--- a/src/main/java/com/teradata/tpcds/Options.java
+++ b/src/main/java/com/teradata/tpcds/Options.java
@@ -26,7 +26,7 @@ public class Options
     public static final String DEFAULT_TABLE = null;
     public static final String DEFAULT_NULL_STRING = "";
     public static final char DEFAULT_SEPARATOR = '|';
-    public static final boolean DEFAULT_TERMINATE = true;
+    public static final boolean DEFAULT_DO_NOT_TERMINATE = false;
     public static final boolean DEFAULT_NO_SEXISM = false;
     public static final int DEFAULT_PARALLELISM = 1;
     public static final boolean DEFAULT_OVERWRITE = false;
@@ -49,8 +49,8 @@ public class Options
     @Option(name = {"--separator"}, title = "separator", description = "Separator between columns (Default: |)")
     public char separator = DEFAULT_SEPARATOR;
 
-    @Option(name = {"--terminate"}, title = "terminate", description = "Terminate each row with a separator (Default: true)")
-    public boolean terminate = DEFAULT_TERMINATE;
+    @Option(name = {"--do-not-terminate"}, title = "do-not-terminate", description = "Do not terminate each row with a separator (Default: false)")
+    public boolean doNotTerminate = DEFAULT_DO_NOT_TERMINATE;
 
     @Option(name = {"--no-sexism"}, title = "no-sexism",
             description = "The reference C implementation picks only male names for the manager fields. " +
@@ -74,7 +74,7 @@ public class Options
                 toTableOptional(table),
                 nullString,
                 separator,
-                terminate,
+                doNotTerminate,
                 noSexism,
                 parallelism,
                 overwrite);

--- a/src/main/java/com/teradata/tpcds/Session.java
+++ b/src/main/java/com/teradata/tpcds/Session.java
@@ -17,6 +17,7 @@ package com.teradata.tpcds;
 import java.util.Optional;
 
 import static com.teradata.tpcds.Options.DEFAULT_DIRECTORY;
+import static com.teradata.tpcds.Options.DEFAULT_DO_NOT_TERMINATE;
 import static com.teradata.tpcds.Options.DEFAULT_NO_SEXISM;
 import static com.teradata.tpcds.Options.DEFAULT_NULL_STRING;
 import static com.teradata.tpcds.Options.DEFAULT_OVERWRITE;
@@ -24,7 +25,6 @@ import static com.teradata.tpcds.Options.DEFAULT_PARALLELISM;
 import static com.teradata.tpcds.Options.DEFAULT_SCALE;
 import static com.teradata.tpcds.Options.DEFAULT_SEPARATOR;
 import static com.teradata.tpcds.Options.DEFAULT_SUFFIX;
-import static com.teradata.tpcds.Options.DEFAULT_TERMINATE;
 
 public class Session
 {
@@ -34,18 +34,18 @@ public class Session
     private final Optional<Table> table;
     private final String nullString;
     private final char separator;
-    private final boolean terminate;
+    private final boolean doNotTerminate;
     private final boolean noSexism;
     private final int parallelism;
     private final int chunkNumber;
     private final boolean overwrite;
 
-    public Session(int scale, String targetDirectory, String suffix, Optional<Table> table, String nullString, char separator, boolean terminate, boolean noSexism, int parallelism, boolean overwrite)
+    public Session(int scale, String targetDirectory, String suffix, Optional<Table> table, String nullString, char separator, boolean doNotTerminate, boolean noSexism, int parallelism, boolean overwrite)
     {
-        this(scale, targetDirectory, suffix, table, nullString, separator, terminate, noSexism, parallelism, 1, overwrite);
+        this(scale, targetDirectory, suffix, table, nullString, separator, doNotTerminate, noSexism, parallelism, 1, overwrite);
     }
 
-    public Session(int scale, String targetDirectory, String suffix, Optional<Table> table, String nullString, char separator, boolean terminate, boolean noSexism, int parallelism, int chunkNumber, boolean overwrite)
+    public Session(int scale, String targetDirectory, String suffix, Optional<Table> table, String nullString, char separator, boolean doNotTerminate, boolean noSexism, int parallelism, int chunkNumber, boolean overwrite)
     {
         this.scaling = new Scaling(scale);
         this.targetDirectory = targetDirectory;
@@ -53,7 +53,7 @@ public class Session
         this.table = table;
         this.nullString = nullString;
         this.separator = separator;
-        this.terminate = terminate;
+        this.doNotTerminate = doNotTerminate;
         this.noSexism = noSexism;
         this.parallelism = parallelism;
         this.chunkNumber = chunkNumber;
@@ -74,7 +74,7 @@ public class Session
                 Optional.of(table),
                 this.nullString,
                 this.separator,
-                this.terminate,
+                this.doNotTerminate,
                 this.noSexism,
                 this.parallelism,
                 this.chunkNumber,
@@ -91,7 +91,7 @@ public class Session
                 this.table,
                 this.nullString,
                 this.separator,
-                this.terminate,
+                this.doNotTerminate,
                 this.noSexism,
                 this.parallelism,
                 this.chunkNumber,
@@ -108,7 +108,7 @@ public class Session
                 this.table,
                 this.nullString,
                 this.separator,
-                this.terminate,
+                this.doNotTerminate,
                 this.noSexism,
                 parallelism,
                 this.chunkNumber,
@@ -125,7 +125,7 @@ public class Session
                 this.table,
                 this.nullString,
                 this.separator,
-                this.terminate,
+                this.doNotTerminate,
                 this.noSexism,
                 this.parallelism,
                 chunkNumber,
@@ -142,7 +142,7 @@ public class Session
                 this.table,
                 this.nullString,
                 this.separator,
-                this.terminate,
+                this.doNotTerminate,
                 noSexism,
                 this.parallelism,
                 this.chunkNumber,
@@ -190,7 +190,7 @@ public class Session
 
     public boolean terminateRowsWithSeparator()
     {
-        return terminate;
+        return !doNotTerminate;
     }
 
     public boolean isSexist()
@@ -234,8 +234,8 @@ public class Session
         if (separator != DEFAULT_SEPARATOR) {
             output.append("--separator ").append(separator).append(" ");
         }
-        if (terminate != DEFAULT_TERMINATE) {
-            output.append("--terminate ");
+        if (doNotTerminate != DEFAULT_DO_NOT_TERMINATE) {
+            output.append("--do-not-terminate ");
         }
         if (noSexism != DEFAULT_NO_SEXISM) {
             output.append("--no-sexism ");


### PR DESCRIPTION
The way the option was previously setup, it was impossible to
generate data without terminating each record with a separator.
This commit renames the option to --do-not-terminate and defaults it
to false.

Fixes https://github.com/Teradata/tpcds/issues/13.