### PR TITLE
Add travis_wait to prevent timeout from no output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ before_install:
 before_cache:
   #make the cache stable between builds by removing build output
   - rm -rf $HOME/.m2/repository/com/teradata
+
+script: travis_wait ./mvnw test


### PR DESCRIPTION
Will print out a line of output every minute for 20 minutes (see
https://docs.travis-ci.com/user/common-build-problems/).  This prevents
travis from timing out when test runs take more than 10 minutes.
