### PR TITLE
Fixes #24 - Teach Table Generator how to write to a HDFS file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,19 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>2.7.1</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/com/teradata/tpcds/Scaling.java
+++ b/src/main/java/com/teradata/tpcds/Scaling.java
@@ -17,6 +17,7 @@ package com.teradata.tpcds;
 import com.teradata.tpcds.distribution.CalendarDistribution;
 import com.teradata.tpcds.type.Date;
 
+import java.io.Serializable;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -39,7 +40,7 @@ import static com.teradata.tpcds.type.Date.JULIAN_DATE_MINIMUM;
 import static com.teradata.tpcds.type.Date.fromJulianDays;
 import static com.teradata.tpcds.type.Date.isLeapYear;
 
-public class Scaling
+public class Scaling implements Serializable
 {
     private final double scale;
     private final Map<Table, Long> tableToRowCountMap = new EnumMap<>(Table.class);


### PR DESCRIPTION
 * Make session & scaling serializable so it can be passed around
 * Teach session factory pattern to take in a hadoop config object
 * Make a serializable hadoop config object to ensure Session is
   serializable